### PR TITLE
Remove C++ build action for now

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Build C++
-        run: |
-          cd cpp/src
-          make
+            #      - name: Build C++
+            #run: |
+            #cd cpp/src
+            #make
 
       - name: Build Python
         run: |


### PR DESCRIPTION
The C++ source code depends on ROOT, which is not included in this repository. Probably need to specify a container in which to run this action.